### PR TITLE
add GetOSName support for Windows 8.1

### DIFF
--- a/Win32.pm
+++ b/Win32.pm
@@ -468,6 +468,15 @@ sub _GetOSName {
 	        $os = "2012";
 	    }
 	    }
+	    elsif ($minor == 3) {
+		if ($producttype == VER_NT_WORKSTATION) {
+		    $os = "8.1";
+		}
+		else {
+		    $os = "2012";
+		    $desc = "R2";
+		}
+	    }
 
         if ($productinfo == PRODUCT_ULTIMATE) {
 		$desc .= " Ultimate";


### PR DESCRIPTION
Adds support to GetOSName() for Windows 8.1.

The 2012 R2 entry is based on the table at http://msdn.microsoft.com/en-us/library/windows/desktop/ms724833%28v=vs.85%29.aspx

Tested on Windows 8.1 Pro, Windows 7 Pro in a cygwin build (this is one of the tests causing my cygwin perl smokes to fail.)

This doesn't attempt to fix cpan #90807