### PR TITLE
Fix build in C++ mode

### DIFF
--- a/Win32.xs
+++ b/Win32.xs
@@ -236,7 +236,7 @@ get_unicode_env(pTHX_ WCHAR *name)
             pfnCreateEnvironmentBlock(&env, token, FALSE))
         {
             size_t name_len = wcslen(name);
-            WCHAR *entry = env;
+            WCHAR *entry = (WCHAR *)env;
             while (*entry) {
                 size_t i;
                 size_t entry_len = wcslen(entry);
@@ -817,7 +817,11 @@ XS(w32_GuidGen)
 
     if (SUCCEEDED(hr)) {
 	LPOLESTR pStr = NULL;
+#ifdef __cplusplus
+	if (SUCCEEDED(StringFromCLSID(guid, &pStr))) {
+#else
 	if (SUCCEEDED(StringFromCLSID(&guid, &pStr))) {
+#endif
             WideCharToMultiByte(CP_ACP, 0, pStr, (int)wcslen(pStr), szGUID,
                                 sizeof(szGUID), NULL, NULL);
             CoTaskMemFree(pStr);


### PR DESCRIPTION
Note that StringFromCLSID() calls StringFromGUID2(), the first parameter of
which is a REFGUID, which is defined differently under C++ compared to C!
From Guiddef.h:

#ifdef __cplusplus
#define REFGUID const GUID &
#else
#define REFGUID const GUID * __MIDL_CONST
#endif

(Based on a patch from Daniel Dragan on perl5-porters:
http://code.activestate.com/lists/perl5-porters/217113/)