### PR TITLE
Provide minimal Windows 10 support

### DIFF
--- a/Win32.pm
+++ b/Win32.pm
@@ -540,7 +540,12 @@ sub _GetOSName {
 	    elsif ($arch == PROCESSOR_ARCHITECTURE_AMD64) {
 		$desc .= " (64-bit)";
 	    }
-	}
+	} 
+	elsif ($major == 10) {
+	    if ($minor == 0) {
+                $os = '10';
+            }
+        }
     }
 
     unless (defined $os) {


### PR DESCRIPTION
This is keeping Perl from building (failure during build tests) on Windows 10, so it is a relatively important change.

I didn't include any of the product family stuff, nor did I differentiate server from workstation, in this - this is the bare minimum needed to get the module to pass tests.