### PR TITLE
XSLoader+delay load DLLs

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,5 +14,8 @@ my %param = (
 );
 $param{NO_META} = 1 if eval "$ExtUtils::MakeMaker::VERSION" >= 6.10_03;
 $param{LIBS} = ['-L/lib/w32api -lole32 -lversion'] if $^O eq "cygwin";
+$param{dynamic_lib} =
+    {OTHERLDFLAGS => '-DELAYLOAD:ole32.dll -DELAYLOAD:version.dll delayimp.lib'}
+    if $Config::Config{cc} =~ /cl/;
 
 WriteMakefile(%param);

--- a/Win32.pm
+++ b/Win32.pm
@@ -5,9 +5,9 @@ package Win32;
     use vars qw|$VERSION $XS_VERSION @ISA @EXPORT @EXPORT_OK|;
 
     require Exporter;
-    require DynaLoader;
+    require XSLoader;
 
-    @ISA = qw|Exporter DynaLoader|;
+    @ISA = qw|Exporter|;
     $VERSION = '0.52';
     $XS_VERSION = $VERSION;
     $VERSION = eval $VERSION;
@@ -647,7 +647,7 @@ sub _GetOSName {
 
 # "no warnings 'redefine';" doesn't work for 5.8.7 and earlier
 local $^W = 0;
-bootstrap Win32;
+XSLoader::load('Win32');
 
 1;
 


### PR DESCRIPTION
Some time savings in loading Win32.pm/Win32.dll, the module was `dmake install`ed between tests.

BEFORE

C:\sources\win32>timeit -f t.dat perl -e"system('perl -MWin32 -e\"0\"') for 0..3
00"

Version Number:   Windows NT 6.1 (Build 7601)
Exit Time:        10:45 pm, Tuesday, January 12 2016
Elapsed Time:     0:00:12.837
Process Time:     0:00:00.390
System Calls:     527642
Context Switches: 90291
Page Faults:      412956
Bytes Read:       39647078
Bytes Written:    1406213
Bytes Other:      1314035

C:\sources\win32>

AFTER delay load
C:\sources\win32>timeit -f t.dat perl -e"system('perl -MWin32 -e\"0\"') for 0..3
00"

Version Number:   Windows NT 6.1 (Build 7601)
Exit Time:        10:37 pm, Tuesday, January 12 2016
Elapsed Time:     0:00:12.388
Process Time:     0:00:00.265
System Calls:     498354
Context Switches: 85755
Page Faults:      396541
Bytes Read:       39622468
Bytes Written:    0
Bytes Other:      1267236

C:\sources\win32>

AFTER XSLoader

C:\sources\win32>timeit -f t.dat perl -e"system('perl -MWin32 -e\"0\"') for 0..3
00"

Version Number:   Windows NT 6.1 (Build 7601)
Exit Time:        10:38 pm, Tuesday, January 12 2016
Elapsed Time:     0:00:10.805
Process Time:     0:00:00.374
System Calls:     426147
Context Switches: 78001
Page Faults:      367246
Bytes Read:       33923778
Bytes Written:    61652
Bytes Other:      1060160

C:\sources\win32>
